### PR TITLE
Handle tsconfigs with comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,17 @@ There's a blog post that's a good introduction to it [Optimizing multi-package a
 
 You can just use it via npx
 
-`npx update-ts-references`
+```
+npx update-ts-references --help
+
+  Usage: update-ts-references [options]
+
+  Options:
+    --help        Show help
+    --cwd         Set working directory. Default: [current path]
+    --discardComments     Discards comments when updating tsconfigs. Default: false
+    --verbose     Show verbose output. Default: false
+```
 
 or you add it as dev dependency and include it in the `postinstall` script in the package.json
 
@@ -19,6 +29,14 @@ or you add it as dev dependency and include it in the `postinstall` script in th
    "postinstall": "update-ts-references"
  },
 ```
+
+## FAQ
+
+> Where are the comments from my tsconfig?
+
+_update-ts-references_ is **not** able to preserve comments in tsconfig files when it is updating the references. If you need comments for the case like, explaining why compiler options are set, please move this part including comments into a second file and use the `extends` functionallity (see [here](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#tsconfig-bases)).
+
+
 # License
 
 Copyright 2020 mobile.de

--- a/package.json
+++ b/package.json
@@ -16,13 +16,17 @@
     "@formatjs/cli": "^2.3.1",
     "glob": "^7.1.6",
     "minimist": "^1.2.5",
-    "mkdirp": "^1.0.4"
+    "mkdirp": "^1.0.4",
+    "readline-sync": "^1.4.10"
   },
   "devDependencies": {
     "eslint": "^7.7.0",
     "eslint-plugin-jest": "^23.20.0",
     "exec-sh": "^0.3.4",
     "jest": "^26.4.0"
+  },
+  "peerDependencies": {
+    "typescript": ">=3.8.0"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "update-ts-references",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "bin": "src/index.js",
   "scripts": {
     "lint": "eslint src tests",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "contributors": [
     {
       "name": "Mirko Kruschke",
-      "email": "mirko.kruschke@team.mobile.de"
+      "email": "mirko.kruschke@gmail.com"
     }
   ],
   "dependencies": {
@@ -31,6 +31,18 @@
   "engines": {
     "node": ">=10.0.0"
   },
+  "license": "MIT",
+  "keywords": [
+    "typescript",
+    "references",
+    "tool",
+    "util",
+    "yarn",
+    "workspaces",
+    "lerna",
+    "monorepo",
+    "packages"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/eBayClassifiedsGroup/update-ts-references.git"

--- a/scripts/prepareTests.sh
+++ b/scripts/prepareTests.sh
@@ -2,4 +2,4 @@
 yarn link
 rm -rf test-run
 cp -R tests/scenarios test-run
-find test-run  -maxdepth 1 -type d \( ! -name 'test-run' \) -exec bash -c "cd {} && yarn link update-ts-references " \;
+find test-run  -maxdepth 1 -type d \( ! -name 'test-run' \) -exec bash -c "cd {} && yarn && yarn link update-ts-references " \;

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const {
   verbose = defaultOptions.verbose,
   help = defaultOptions.help,
   h = defaultOptions.help,
+  discardComments = defaultOptions.discardComments,
 } = minimist(process.argv.slice(2));
 
 if (help || h) {
@@ -17,6 +18,7 @@ if (help || h) {
   Options:
     --help        Show help
     --cwd         Set working directory. Default: ${defaultOptions.cwd}
+    --discardComments     Discards comments when updating tsconfigs. Default: ${defaultOptions.discardComments}
     --verbose     Show verbose output. Default: ${defaultOptions.verbose}
   `);
   process.exit(0);
@@ -27,6 +29,7 @@ const run = async () => {
     await execute({
       cwd,
       verbose,
+      discardComments,
     });
   } catch (error) {
     console.error(error);

--- a/tests/scenarios/lerna/package.json
+++ b/tests/scenarios/lerna/package.json
@@ -1,4 +1,7 @@
 {
   "name": "lerna",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "devDependencies": {
+    "typescript": "3.8.3"
+  }
 }

--- a/tests/scenarios/lerna/tsconfig.json
+++ b/tests/scenarios/lerna/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "files": []
+  "files": [],
+  "compilerOptions": {
+    /* Basic Options */
+    // "allowJs": true,
+    "composite": true
+  }
 }

--- a/tests/scenarios/yarn-ws/package.json
+++ b/tests/scenarios/yarn-ws/package.json
@@ -1,10 +1,14 @@
 {
   "name": "yarn-workspace",
   "version": "0.0.1",
+  "private": true,
   "workspaces": [
     "workspace-a",
     "workspace-b",
     "shared/*",
     "utils/**"
-  ]
+  ],
+  "devDependencies": {
+    "typescript": "latest"
+  }
 }

--- a/tests/scenarios/yarn-ws/tsconfig.json
+++ b/tests/scenarios/yarn-ws/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "files": []
+  "files": [],
+  "compilerOptions": {
+    /* Basic Options */
+    // "allowJs": true,
+    "composite": true
+  }
 }

--- a/tests/update-ts-references.test.js
+++ b/tests/update-ts-references.test.js
@@ -7,7 +7,7 @@ const compilerOptions = { outDir: 'dist', rootDir: 'src' };
 
 const setup = async (rootFolder) => {
   try {
-    await execSh('npx update-ts-references', {
+    await execSh('npx update-ts-references --discardComments', {
       stdio: null,
       cwd: rootFolder,
     });
@@ -23,6 +23,9 @@ const tsconfigs = [
   [
     '.',
     {
+      compilerOptions: {
+        composite: true,
+      },
       files: [],
       references: [
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3317,6 +3317,11 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
+readline-sync@^1.4.10:
+  version "1.4.10"
+  resolved "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
+  integrity sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==
+
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"


### PR DESCRIPTION
# Why the change
Typescript config files are not simple JSON files where comments are forbidden, there are similar to JSON5 files where you can add comments.

# What is the change
- Enable reading of configs with comments
- Warn if comments are detected and added a continue Y/N choice
- Add a new option to skip the warning
- Added FAQ section in the readme

# How to test
I added integration tests for the new option, but please test it without the new option by hand, because in a follow-up PR there will be a new enhancement to automatically create base configs and reference them via extends.