### PR TITLE
feat: replace trailing whitespace with a newline

### DIFF
--- a/src/update-ts-references.js
+++ b/src/update-ts-references.js
@@ -138,16 +138,15 @@ Do you want to discard them and proceed?`
     }
     if (!isEqual) {
       if (check === false) {
-        const newTsConfig = `${JSON.stringify(
+        const newTsConfig = JSON.stringify(
           {
             ...config,
             references: references.length ? references : undefined,
           },
           null,
           2
-        )}
-  `;
-        fs.writeFileSync(tsconfigFilePath, newTsConfig);
+        );
+        fs.writeFileSync(tsconfigFilePath, newTsConfig + '\n');
       }
       return 1;
     }


### PR DESCRIPTION
This replaces some trailing whitespace with a newline, making Git happy. :-)

Here's a diff showing the current (probably undesired) behaviour on the last two lines:

```diff
diff --git a/path/tsconfig.json b/path/tsconfig.json
index f4d712c..a8fae12 100644
--- a/path/tsconfig.json
+++ b/path/tsconfig.json
@@ -4,9 +4,16 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "references": [
-    { "path": "../../lib/math/tsconfig.json" },
-    { "path": "../../lib/string/tsconfig.json" }
+    {
+      "path": "../../lib/math"
+    },
+    {
+      "path": "../../lib/string"
+    }
   ]
 }
+  
\ No newline at end of file
```

Thanks for the awesome tool!