### PR TITLE
fix!: use posix file path style for reference paths 

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,3 +26,19 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: yarn
     - run: yarn test
+  
+  windows:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }} with windows
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: yarn
+    - run: yarn test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "update-ts-references",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "bin": "src/index.js",
   "scripts": {
     "lint": "eslint src tests",

--- a/src/update-ts-references.js
+++ b/src/update-ts-references.js
@@ -99,12 +99,18 @@ const getReferencesFromDependencies = (
     .sort((refA, refB) => (refA.path > refB.path ? 1 : -1));
 };
 
+const ensurePosixPathStyle = (reference) => ({
+  ...reference,
+  path: reference.path.split(path.sep).join(path.posix.sep),
+});
+
 const updateTsConfig = (
-  references,
+  win32OrPosixReferences,
   discardComments,
   check,
   { packageDir } = { packageDir: process.cwd() }
 ) => {
+  const references = (win32OrPosixReferences || []).map(ensurePosixPathStyle);
   const tsconfigFilePath = path.join(packageDir, TS_CONFIG_JSON);
   let pureJson = true;
   try {
@@ -131,7 +137,7 @@ Do you want to discard them and proceed?`
     }
     let isEqual = false;
     try {
-      assert.deepEqual(config.references || [], references || []);
+      assert.deepEqual(config.references || [], references);
       isEqual = true;
     } catch {
       // ignore me


### PR DESCRIPTION
# Why the change
To improve cross OS setups for teams. (See issue #9)

# What is the change
- use posix path implementation
- added windows test run to the automated checks

# How to test
- automated test should have passed 