### PR TITLE
chore: run test over src instead npx

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -42,3 +42,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: yarn
     - run: yarn test
+      env: 
+        NODE_DEBUG: child_process

--- a/tests/update-ts-references.test.js
+++ b/tests/update-ts-references.test.js
@@ -13,10 +13,11 @@ const rootFolderYarnCheckNoChanges = path.join(
 );
 const rootFolderLerna = path.join(process.cwd(), 'test-run/lerna');
 const compilerOptions = { outDir: 'dist', rootDir: 'src' };
-
+const pathSrc = path.resolve('src/index.js');
+console.log("--pathSrc", pathSrc);
 const setup = async (rootFolder) => {
   try {
-    await execSh('npx update-ts-references --discardComments', {
+    await execSh(`node ${pathSrc} --discardComments`, {
       stdio: null,
       cwd: rootFolder,
     });
@@ -167,7 +168,7 @@ test('Support yarn workspaces with noHoist', async () => {
 test('Detect changes with the --check option', async () => {
   let errorCode = 0;
   try {
-    await execSh('npx update-ts-references --check', {
+    await execSh(`node ${pathSrc} --check`, {
       stdio: null,
       cwd: rootFolderYarnCheck,
     });
@@ -190,7 +191,7 @@ test('Detect changes with the --check option', async () => {
 test('No changes detected with the --check option', async () => {
   let errorCode = 0;
   try {
-    await execSh('npx update-ts-references --check', {
+    await execSh(`node ${pathSrc} --check`, {
       stdio: null,
       cwd: rootFolderYarnCheckNoChanges,
     });


### PR DESCRIPTION
I think is more reliable in this way, otherwise need to rely in a previous published version

I'll check windows failure test