### PR TITLE
ci: fix windows test execution

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,18 +26,19 @@ jobs:
       - run: yarn
       - run: yarn test
 
-  # windows:
-  #   runs-on: windows-latest
+  windows:
+    runs-on: windows-latest
 
-  #   strategy:
-  #     matrix:
-  #       node-version: [14.x]
+    strategy:
+      matrix:
+        node-version: [14.x]
 
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Use Node.js ${{ matrix.node-version }} with windows
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #     - run: yarn
-  #     - run: yarn test
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }} with windows
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn
+      - run: scripts\prepareTests.ps1
+      - run: yarn jest

--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ or you add it as dev dependency and include it in the `postinstall` script in th
 
 ## FAQ
 
-> Why is my pnpm workspace alias not working?
+### Why is my pnpm workspace alias not working?
+
 _update-ts-references_ is currently not supporting [Referencing workspace packages through aliases](https://pnpm.js.org/workspaces#referencing-workspace-packages-through-aliases) yet. See issue #13 
 
-> Where are the comments from my tsconfig?
+### Where are the comments from my tsconfig?
 
 _update-ts-references_ is **not** able to preserve comments in tsconfig files when it is updating the references. If you need comments for the case like, explaining why compiler options are set, please move this part including comments into a second file and use the `extends` functionallity (see [here](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#tsconfig-bases)).
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "bin": "src/index.js",
   "scripts": {
     "lint": "eslint src tests",
-    "test": "scripts/prepareTests.sh && jest tests "
+    "test": "scripts/prepareTests.sh && jest tests ",
+    "jest": "jest tests "
   },
   "contributors": [
     {

--- a/scripts/prepareTests.ps1
+++ b/scripts/prepareTests.ps1
@@ -1,0 +1,6 @@
+Invoke-Expression "yarn link"
+Remove-Item .\test-run -Confirm:$false -Force -Recurse -ErrorAction Ignore
+Copy-Item .\test-scenarios -Destination .\test-run -Recurse
+$prevLocation = Get-Location
+Get-ChildItem .\test-run | ForEach-Object { Set-Location $_.FullName; Invoke-Expression "yarn"; Invoke-Expression "yarn link update-ts-references" }
+Set-Location $prevLocation

--- a/tests/update-ts-references.test.js
+++ b/tests/update-ts-references.test.js
@@ -1,21 +1,26 @@
 const execSh = require('exec-sh').promise;
 const path = require('path');
+const fs = require('fs');
 
-const rootFolderYarn = path.join(process.cwd(), 'test-run/yarn-ws');
+const rootFolderYarn = path.join(process.cwd(), 'test-run', 'yarn-ws');
 const rootFolderYarnNohoist = path.join(
   process.cwd(),
-  'test-run/yarn-ws-nohoist'
+  'test-run', 'yarn-ws-nohoist'
 );
-const rootFolderPnpm = path.join(process.cwd(), 'test-run/pnpm');
-const rootFolderYarnCheck = path.join(process.cwd(), 'test-run/yarn-ws-check');
+const rootFolderPnpm = path.join(process.cwd(), 'test-run', 'pnpm');
+const rootFolderYarnCheck = path.join(process.cwd(), 'test-run', 'yarn-ws-check');
 const rootFolderYarnCheckNoChanges = path.join(
   process.cwd(),
-  'test-run/yarn-ws-check-no-changes'
+  'test-run', 'yarn-ws-check-no-changes'
 );
-const rootFolderLerna = path.join(process.cwd(), 'test-run/lerna');
+const rootFolderLerna = path.join(process.cwd(), 'test-run', 'lerna');
 const compilerOptions = { outDir: 'dist', rootDir: 'src' };
 
 const setup = async (rootFolder) => {
+  if (!fs.existsSync(rootFolder)) {
+    throw new Error(`folder is missing -> ${rootFolder}`);
+  }
+
   try {
     await execSh('npx update-ts-references --discardComments', {
       stdio: null,


### PR DESCRIPTION
# Why the change
windows test execution isn't working with the windows-latest environment anymore

# What is the change
- use powershell on windows 
- use path join properly

# How to test
- automated test should have passed 

![image](https://user-images.githubusercontent.com/1651782/113628799-ba83df80-9665-11eb-92ac-b660690e7687.png)
