### PR TITLE
feat: preserve manually set reference option prepend

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "update-ts-references",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "bin": "src/index.js",
   "scripts": {
     "lint": "eslint src tests",

--- a/src/update-ts-references.js
+++ b/src/update-ts-references.js
@@ -154,9 +154,17 @@ Do you want to discard them and proceed?`
         process.exit(0);
       }
     }
+
+    const currentReferences = config.references || [];
+
+    const mergedReferences = references.map((ref) => ({
+      ...ref,
+      ...currentReferences.find((currentRef) => currentRef.path === ref.path),
+    }));
+
     let isEqual = false;
     try {
-      assert.deepEqual(config.references || [], references);
+      assert.deepEqual(currentReferences, mergedReferences);
       isEqual = true;
     } catch {
       // ignore me
@@ -166,7 +174,7 @@ Do you want to discard them and proceed?`
         const newTsConfig = JSON.stringify(
           {
             ...config,
-            references: references.length ? references : undefined,
+            references: mergedReferences.length ? mergedReferences : undefined,
           },
           null,
           2

--- a/test-scenarios/yarn-ws/workspace-a/tsconfig.json
+++ b/test-scenarios/yarn-ws/workspace-a/tsconfig.json
@@ -2,5 +2,14 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src"
-  }
+  },
+  "references": [
+    {
+      "path": "../utils/foos/foo-a",
+      "prepend": false
+    },
+    {
+      "path": "../some/old/ref"
+    }
+  ]
 }

--- a/tests/update-ts-references.test.js
+++ b/tests/update-ts-references.test.js
@@ -29,108 +29,146 @@ const setup = async (rootFolder) => {
   }
 };
 
-const tsconfigs = [
-  [
-    '.',
-    {
-      compilerOptions: {
-        composite: true,
+const rootTsConfig = [
+  '.',
+  {
+    compilerOptions: {
+      composite: true,
+    },
+    files: [],
+    references: [
+      {
+        path: 'workspace-a',
       },
-      files: [],
-      references: [
-        {
-          path: 'workspace-a',
-        },
-        {
-          path: 'workspace-b',
-        },
-        {
-          path: 'shared/workspace-c',
-        },
-        {
-          path: 'shared/workspace-d',
-        },
-        {
-          path: 'utils/foos/foo-a',
-        },
-        {
-          path: 'utils/foos/foo-b',
-        },
-      ],
-    },
-  ],
-  [
-    './workspace-a',
-    {
-      compilerOptions,
-      references: [
-        {
-          path: '../utils/foos/foo-a',
-        },
-        {
-          path: '../workspace-b',
-        },
-      ],
-    },
-  ],
-  [
-    './workspace-b',
-    {
-      compilerOptions,
+      {
+        path: 'workspace-b',
+      },
+      {
+        path: 'shared/workspace-c',
+      },
+      {
+        path: 'shared/workspace-d',
+      },
+      {
+        path: 'utils/foos/foo-a',
+      },
+      {
+        path: 'utils/foos/foo-b',
+      },
+    ],
+  },
+];
 
-      references: [
-        {
-          path: '../utils/foos/foo-b',
-        },
-      ],
-    },
-  ],
-  [
-    './shared/workspace-c',
-    {
-      compilerOptions,
+const wsATsConfig = [
+  './workspace-a',
+  {
+    compilerOptions,
+    references: [
+      {
+        path: '../utils/foos/foo-a',
+      },
+      {
+        path: '../workspace-b',
+      },
+    ],
+  },
+];
 
-      references: [
-        {
-          path: '../../utils/foos/foo-a',
-        },
-      ],
-    },
-  ],
-  [
-    './shared/workspace-d',
-    {
-      compilerOptions,
+const wsBTsConfig = [
+  './workspace-b',
+  {
+    compilerOptions,
 
-      references: [
-        {
-          path: '../workspace-c',
-        },
-      ],
-    },
-  ],
-  [
-    './utils/foos/foo-a',
-    {
-      compilerOptions,
-      references: [
-        {
-          path: '../foo-b',
-        },
-      ],
-    },
-  ],
-  [
-    './utils/foos/foo-b',
-    {
-      compilerOptions,
-      references: undefined,
-    },
-  ],
+    references: [
+      {
+        path: '../utils/foos/foo-b',
+      },
+    ],
+  },
+];
+
+const wsCTsConfig = [
+  './shared/workspace-c',
+  {
+    compilerOptions,
+
+    references: [
+      {
+        path: '../../utils/foos/foo-a',
+      },
+    ],
+  },
+];
+
+const wsDTsConfig = [
+  './shared/workspace-d',
+  {
+    compilerOptions,
+
+    references: [
+      {
+        path: '../workspace-c',
+      },
+    ],
+  },
+];
+
+const fooATsConfig = [
+  './utils/foos/foo-a',
+  {
+    compilerOptions,
+    references: [
+      {
+        path: '../foo-b',
+      },
+    ],
+  },
+];
+
+const fooBTsConfig = [
+  './utils/foos/foo-b',
+  {
+    compilerOptions,
+    references: undefined,
+  },
+];
+
+const tsconfigs = [
+  rootTsConfig,
+  wsATsConfig,
+  wsBTsConfig,
+  wsCTsConfig,
+  wsDTsConfig,
+  fooATsConfig,
+  fooBTsConfig,
 ];
 
 test('Support yarn workspaces', async () => {
   await setup(rootFolderYarn);
+
+  const tsconfigs = [
+    rootTsConfig,
+    [
+      './workspace-a',
+      {
+        compilerOptions,
+        references: [
+          {
+            path: '../utils/foos/foo-a',
+            prepend: false,
+          },
+          {
+            path: '../workspace-b',
+          },
+        ],
+      },
+    ],
+    wsBTsConfig,
+    wsCTsConfig,
+    wsDTsConfig,
+    fooATsConfig,
+    fooBTsConfig,
+  ];
 
   tsconfigs.forEach((tsconfig) => {
     const [configPath, config] = tsconfig;


### PR DESCRIPTION
# Why the change
It is possible to optimize the output with the option `prepend` on a reference (see [here](https://www.typescriptlang.org/docs/handbook/project-references.html#prepend-with-outfile)). This change will preserve the manually set option.

# What is the change
- added logic to preserve the option prepend

# How to test
- automated test should have passed 