### PR TITLE
feat: add configName fallback resolution incl. ref path generation fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "update-ts-references",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "bin": "src/index.js",
   "scripts": {
     "lint": "eslint src tests",

--- a/test-scenarios/yarn-ws-custom-tsconfig-names/utils/foos/foo-b/tsconfig.dev.json
+++ b/test-scenarios/yarn-ws-custom-tsconfig-names/utils/foos/foo-b/tsconfig.dev.json
@@ -1,6 +1,0 @@
-{
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  }
-}

--- a/test-scenarios/yarn-ws-custom-tsconfig-names/utils/foos/foo-b/tsconfig.json
+++ b/test-scenarios/yarn-ws-custom-tsconfig-names/utils/foos/foo-b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+  },"references": [
+      
+    {
+      "path": "../some/old/ref"
+    }
+  ]
+}

--- a/test-scenarios/yarn-ws-custom-tsconfig-names/workspace-a/tsconfig.dev.json
+++ b/test-scenarios/yarn-ws-custom-tsconfig-names/workspace-a/tsconfig.dev.json
@@ -5,7 +5,7 @@
   },
   "references": [
     {
-      "path": "../utils/foos/foo-a",
+      "path": "../utils/foos/foo-a/tsconfig.dev.json",
       "prepend": false
     },
     {

--- a/tests/update-ts-references.test.js
+++ b/tests/update-ts-references.test.js
@@ -36,10 +36,9 @@ const setup = async (rootFolder, configName) => {
   try {
     await execSh(
       `npx update-ts-references --discardComments${
-        configName ? ` --configName ${configName}` : ''
+      configName ? ` --configName ${configName}` : ''
       }`,
       {
-        stdio: null,
         cwd: rootFolder,
       }
     );
@@ -292,32 +291,92 @@ test('Support custom tsconfig names', async () => {
   await setup(rootFolder, configName);
 
   const tsconfigs = [
-    rootTsConfig,
+    [
+      '.',
+      {
+        compilerOptions: {
+          composite: true,
+        },
+        files: [],
+        references: [
+          {
+            path: 'workspace-a/tsconfig.dev.json',
+          },
+          {
+            path: 'workspace-b/tsconfig.dev.json',
+          },
+          {
+            path: 'shared/workspace-c/tsconfig.dev.json',
+          },
+          {
+            path: 'shared/workspace-d/tsconfig.dev.json',
+          },
+          {
+            path: 'utils/foos/foo-a/tsconfig.dev.json',
+          },
+          {
+            path: 'utils/foos/foo-b',
+          },
+        ],
+      },
+    ],
     [
       './workspace-a',
       {
         compilerOptions,
         references: [
           {
-            path: '../utils/foos/foo-a',
+            path: '../utils/foos/foo-a/tsconfig.dev.json',
             prepend: false,
           },
           {
-            path: '../workspace-b',
+            path: '../workspace-b/tsconfig.dev.json',
           },
         ],
       },
     ],
     wsBTsConfig,
-    wsCTsConfig,
-    wsDTsConfig,
-    fooATsConfig,
-    fooBTsConfig,
+    [
+      './shared/workspace-c',
+      {
+        compilerOptions,
+
+        references: [
+          {
+            path: '../../utils/foos/foo-a/tsconfig.dev.json',
+          },
+        ],
+      },
+    ],
+    [
+      './shared/workspace-d',
+      {
+        compilerOptions,
+
+        references: [
+          {
+            path: '../workspace-c/tsconfig.dev.json',
+          },
+        ],
+      },
+    ],
+    [
+      './utils/foos/foo-a',
+      {
+        compilerOptions,
+        references: [
+          {
+            path: '../foo-b',
+          },
+        ],
+      },
+    ],
+    [...fooBTsConfig, 'tsconfig.json'],
   ];
 
   tsconfigs.forEach((tsconfig) => {
-    const [configPath, config] = tsconfig;
-    expect(require(path.join(rootFolder, configPath, configName))).toEqual(
+    const [configPath, config, configNameOverride] = tsconfig;
+    expect(require(path.join(rootFolder, configPath, configNameOverride || configName))).toEqual(
       config
     );
   });


### PR DESCRIPTION
# Why the change
references paths where wrongly generated when using the `--configName` param (read more Issue #22) 

# What is the change
- the provided configName will now appended correctly to the path (fix)
- added fallback resolution to tsconfig.json if the configName couldn't be resolved

# How to test
- automated test should have passed 