### PR TITLE
fix: unofficial support of node v8

### DIFF
--- a/src/update-ts-references.js
+++ b/src/update-ts-references.js
@@ -105,7 +105,7 @@ const getReferencesFromDependencies = (
 
   if (Object.keys(mergedDependencies).includes(packageName)) {
     throw new Error(
-      `This package ${packageName} references itself, please check dependencies in package.json`
+      `This package ${packageName} references itself, please check dependencies in package.json`
     );
   }
 
@@ -146,7 +146,7 @@ const updateTsConfig = (
   let pureJson = true;
   try {
     require(tsconfigFilePath);
-  } catch {
+  } catch (e) {
     pureJson = false;
   }
 
@@ -178,7 +178,7 @@ Do you want to discard them and proceed ? `
     try {
       assert.deepEqual(currentReferences, mergedReferences);
       isEqual = true;
-    } catch {
+    } catch (e) {
       // ignore me
     }
     if (!isEqual) {


### PR DESCRIPTION
With some additional changes(installing `jest@25`, and running the working version of the script instead of `npx update-ts-references`), I was also able to run tests, and they pass.
I can add those to this PR + changes to the CI, etc. If you are open to those.