### PR TITLE
feat: support local multi target ts projects

### DIFF
--- a/src/update-ts-references.js
+++ b/src/update-ts-references.js
@@ -168,11 +168,17 @@ Do you want to discard them and proceed ? `
     }
 
     const currentReferences = config.references || [];
+    const localReferences = currentReferences.filter(it => it.path.startsWith('./') || !it.path.startsWith('.'))
 
-    const mergedReferences = references.map((ref) => ({
-      ...ref,
-      ...currentReferences.find((currentRef) => currentRef.path === ref.path),
-    }));
+    const mergedReferences = [
+      // Filter local references that are not in the generated reference list.
+      ...localReferences.filter((localRef) => references.findIndex((ref) => ref.path === localRef.path) === -1),
+      // Merge items in the generated reference list with current items.
+      ...references.map((ref) => ({
+        ...ref,
+        ...currentReferences.find((currentRef) => currentRef.path === ref.path),
+      })),
+    ];
 
     let isEqual = false;
     try {

--- a/test-scenarios/lerna/shared/workspace-c/tsconfig.default.json
+++ b/test-scenarios/lerna/shared/workspace-c/tsconfig.default.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/test-scenarios/lerna/shared/workspace-c/tsconfig.json
+++ b/test-scenarios/lerna/shared/workspace-c/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  }
+  "references": [
+    {
+      "path": "./tsconfig.default.json"
+    }
+  ]
 }

--- a/test-scenarios/pnpm/shared/workspace-c/tsconfig.default.json
+++ b/test-scenarios/pnpm/shared/workspace-c/tsconfig.default.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/test-scenarios/pnpm/shared/workspace-c/tsconfig.json
+++ b/test-scenarios/pnpm/shared/workspace-c/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  }
+  "references": [
+    {
+      "path": "./tsconfig.default.json"
+    }
+  ]
 }

--- a/test-scenarios/yarn-ws-check-no-changes/shared/workspace-c/tsconfig.default.json
+++ b/test-scenarios/yarn-ws-check-no-changes/shared/workspace-c/tsconfig.default.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "references": [
+    {
+      "path": "../../utils/foos/foo-a"
+    }
+  ]
+}
+  

--- a/test-scenarios/yarn-ws-check-no-changes/shared/workspace-c/tsconfig.json
+++ b/test-scenarios/yarn-ws-check-no-changes/shared/workspace-c/tsconfig.json
@@ -1,12 +1,7 @@
 {
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  },
   "references": [
     {
-      "path": "../../utils/foos/foo-a"
+      "path": "./tsconfig.default.json"
     }
   ]
 }
-  

--- a/test-scenarios/yarn-ws-check/shared/workspace-c/tsconfig.default.json
+++ b/test-scenarios/yarn-ws-check/shared/workspace-c/tsconfig.default.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/test-scenarios/yarn-ws-check/shared/workspace-c/tsconfig.json
+++ b/test-scenarios/yarn-ws-check/shared/workspace-c/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  }
+  "references": [
+    {
+      "path": "./tsconfig.default.json"
+    }
+  ]
 }

--- a/test-scenarios/yarn-ws-custom-tsconfig-names/shared/workspace-c/tsconfig.default.json
+++ b/test-scenarios/yarn-ws-custom-tsconfig-names/shared/workspace-c/tsconfig.default.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/test-scenarios/yarn-ws-custom-tsconfig-names/shared/workspace-c/tsconfig.dev.json
+++ b/test-scenarios/yarn-ws-custom-tsconfig-names/shared/workspace-c/tsconfig.dev.json
@@ -1,6 +1,7 @@
 {
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  }
+  "references": [
+    {
+      "path": "./tsconfig.default.json"
+    }
+  ]
 }

--- a/test-scenarios/yarn-ws-nohoist/shared/workspace-c/tsconfig.default.json
+++ b/test-scenarios/yarn-ws-nohoist/shared/workspace-c/tsconfig.default.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/test-scenarios/yarn-ws-nohoist/shared/workspace-c/tsconfig.json
+++ b/test-scenarios/yarn-ws-nohoist/shared/workspace-c/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  }
+  "references": [
+    {
+      "path": "./tsconfig.default.json"
+    }
+  ]
 }

--- a/test-scenarios/yarn-ws/shared/workspace-c/tsconfig.default.json
+++ b/test-scenarios/yarn-ws/shared/workspace-c/tsconfig.default.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/test-scenarios/yarn-ws/shared/workspace-c/tsconfig.json
+++ b/test-scenarios/yarn-ws/shared/workspace-c/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  }
+  "references": [
+    {
+      "path": "./tsconfig.default.json"
+    }
+  ]
 }

--- a/tests/update-ts-references.test.js
+++ b/tests/update-ts-references.test.js
@@ -111,9 +111,10 @@ const wsBTsConfig = [
 const wsCTsConfig = [
   './shared/workspace-c',
   {
-    compilerOptions,
-
     references: [
+      {
+        path: './tsconfig.default.json',
+      },
       {
         path: '../../utils/foos/foo-a',
       },


### PR DESCRIPTION
`update-ts-references` is a great tool for us at https://github.com/open-telemetry/opentelemetry-js to update project references!

However, several targets for a single package can exist in our project. For example, a package can produce 3 different build outputs: 1. default one for Node.js consumers, 2. es5 for browser consumers, 3. esnext with esm for modern browser consumers.

It can be a pain for us to maintain references in each of these targets, as the only difference between them is the `compilerOptions`.

If `update-ts-references` can preserve package's local ts config references, we can create an entrypoint tsconfig for `update-ts-references` to keep track of project's dependencies and split all targets into separate tsconfig files.

See also: https://github.com/open-telemetry/opentelemetry-js/pull/3169