### PR TITLE
feat!: required changes for TypeScript 6

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+lts/jod

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "update-ts-references",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "description": "Updates TypeScript references automatically while using workspaces",
   "bin": "src/index.js",
   "scripts": {

--- a/src/update-ts-references.js
+++ b/src/update-ts-references.js
@@ -183,16 +183,11 @@ const getReferencesFromDependencies = (
         .sort((refA, refB) => (refA.path > refB.path ? 1 : -1));
 };
 
-const ensureLeadingDotSlash=(p)=> {
-    if (!p || path.isAbsolute(p) || p.startsWith('./') || p.startsWith('../')) {
+const ensureLeadingDotSlash = (p) => {
+    if (p == null || path.isAbsolute(p) || p.startsWith('.' + path.sep) || p.startsWith('..' + path.sep)) {
         return p;
     }
-
-    if (p.length === 0) {
-        return '.'
-    }
-
-    return './' + p;
+    return p.length === 0 ? '.' : '.' + path.sep + p;
 }
 
 const ensurePosixPathStyle = (reference) => ({
@@ -454,4 +449,4 @@ const execute = async ({
     return changesCount;
 };
 
-module.exports = { execute, defaultOptions };
+module.exports = { execute, defaultOptions, ensureLeadingDotSlash };

--- a/src/update-ts-references.js
+++ b/src/update-ts-references.js
@@ -153,7 +153,7 @@ const getReferencesFromDependencies = (
         .reduce((referenceArray, dependency) => {
             if (packagesMap.has(dependency)) {
                 const { packageDir: dependencyDir } = packagesMap.get(dependency);
-                const relativePath = path.relative(packageDir, dependencyDir);
+                const relativePath = ensureLeadingDotSlash(path.relative(packageDir, dependencyDir));
                 const detectedConfig = detectTSConfig(dependencyDir, configName)
                 if (detectedConfig !== null) {
                     return [
@@ -182,6 +182,18 @@ const getReferencesFromDependencies = (
         }, [])
         .sort((refA, refB) => (refA.path > refB.path ? 1 : -1));
 };
+
+const ensureLeadingDotSlash=(p)=> {
+    if (!p || path.isAbsolute(p) || p.startsWith('./') || p.startsWith('../')) {
+        return p;
+    }
+
+    if (p.length === 0) {
+        return '.'
+    }
+
+    return './' + p;
+}
 
 const ensurePosixPathStyle = (reference) => ({
     ...reference,
@@ -381,8 +393,8 @@ const execute = async ({
         if (detectedConfig) {
             rootReferenceCandidates.push(ensurePosixPathStyle({
                 name: packageName,
-                path: path.join(path.relative(cwd, packageEntry.packageDir), detectedConfig !== TSCONFIG_JSON ? detectedConfig : ''),
-                folder: path.relative(cwd, packageEntry.packageDir),
+                path: path.join(ensureLeadingDotSlash(path.relative(cwd, packageEntry.packageDir)), detectedConfig !== TSCONFIG_JSON ? detectedConfig : ''),
+                folder: ensureLeadingDotSlash(path.relative(cwd, packageEntry.packageDir)),
             }));
             const references = (getReferencesFromDependencies(
                 configName,

--- a/tests/ensureLeadingDotSlash.test.js
+++ b/tests/ensureLeadingDotSlash.test.js
@@ -1,0 +1,37 @@
+const path = require('path');
+const { ensureLeadingDotSlash } = require('../src/update-ts-references');
+
+test('returns null as-is', () => {
+    expect(ensureLeadingDotSlash(null)).toBe(null);
+});
+
+test('returns undefined as-is', () => {
+    expect(ensureLeadingDotSlash(undefined)).toBe(undefined);
+});
+
+test('returns . for empty string', () => {
+    expect(ensureLeadingDotSlash('')).toBe('.');
+});
+
+test('returns absolute path as-is', () => {
+    const p = path.resolve('/some/absolute/path');
+    expect(ensureLeadingDotSlash(p)).toBe(p);
+});
+
+test('returns path already starting with .' + path.sep + ' as-is', () => {
+    const p = '.' + path.sep + 'foo';
+    expect(ensureLeadingDotSlash(p)).toBe(p);
+});
+
+test('returns path already starting with ..' + path.sep + ' as-is', () => {
+    const p = '..' + path.sep + 'foo';
+    expect(ensureLeadingDotSlash(p)).toBe(p);
+});
+
+test('prepends .' + path.sep + ' to a plain relative path', () => {
+    expect(ensureLeadingDotSlash('foo')).toBe('.' + path.sep + 'foo');
+});
+
+test('prepends .' + path.sep + ' to a nested relative path', () => {
+    expect(ensureLeadingDotSlash('foo' + path.sep + 'bar')).toBe('.' + path.sep + 'foo' + path.sep + 'bar');
+});

--- a/tests/update-ts-references.test.js
+++ b/tests/update-ts-references.test.js
@@ -334,10 +334,10 @@ test('create paths mappings ', async () => {
             compilerOptions: {
                 composite: true,
                 paths: {
-                    "workspace-a": ["workspace-a/src"],
-                    "workspace-b": ["workspace-b"],
-                    "foo-a": ["utils/foos/foo-a/src"],
-                    "foo-b": ["utils/foos/foo-b/src"]
+                    "workspace-a": ["./workspace-a/src"],
+                    "workspace-b": ["./workspace-b"],
+                    "foo-a": ["./utils/foos/foo-a/src"],
+                    "foo-b": ["./utils/foos/foo-b/src"]
                 }
             },
             files: [],

--- a/tests/update-ts-references.yaml.test.js
+++ b/tests/update-ts-references.yaml.test.js
@@ -172,7 +172,7 @@ test('receive options via the config', async () => {
         {
             compilerOptions: {
                 composite: true,
-                paths:{"workspace-a": ["workspace-a/src"]}
+                paths:{"workspace-a": ["./workspace-a/src"]}
 },
             files: [],
             references: [
@@ -226,7 +226,7 @@ test('receive options for a different usecase', async () => {
         {
             compilerOptions: {
                 composite: true,
-                paths:{"workspace-a": ["workspace-a/src"]}
+                paths:{"workspace-a": ["./workspace-a/src"]}
             },
             files: [],
             references: [


### PR DESCRIPTION
TypeScript 6 requires relative paths in `tsconfig.json` files to start with a `.`. if this is not the case it will not be able to find the dependencies.

This change fixes the issue and ensures relative paths start with a `.`.

Furthermore, the `.nvmrc` has been updated to use `lts/jod`, which matches the `engines` entry in the `package.json`.